### PR TITLE
makefile: Apply lowercase to module names

### DIFF
--- a/arm/Makefile
+++ b/arm/Makefile
@@ -1,3 +1,3 @@
-MODULE=qDSA
+MODULE=qdsa
 DIRS += asm
 include $(RIOTBASE)/Makefile.base

--- a/avr/Makefile
+++ b/avr/Makefile
@@ -1,3 +1,3 @@
-MODULE=qDSA
+MODULE=qdsa
 DIRS += asm
 include $(RIOTBASE)/Makefile.base

--- a/cref/Makefile
+++ b/cref/Makefile
@@ -1,2 +1,2 @@
-MODULE=qDSA
+MODULE=qdsa
 include $(RIOTBASE)/Makefile.base


### PR DESCRIPTION
It seems like this is the only package/module that is uppercase.